### PR TITLE
playwrightの導入

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -41,3 +41,27 @@ jobs:
 
       - name: Build application
         run: npm run build
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.0.5",
+        "@playwright/test": "^1.53.1",
         "@tailwindcss/postcss": "^4.1.10",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -1731,6 +1732,22 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz",
+      "integrity": "sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4092,6 +4109,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
+      "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
+      "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "check": "biome check --write .",
     "test": "vitest",
     "test:watch": "vitest --watch",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "repository": {
     "type": "git",
@@ -33,6 +36,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.5",
+    "@playwright/test": "^1.53.1",
     "@tailwindcss/postcss": "^4.1.10",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,70 @@
+import { defineConfig, devices } from "@playwright/test"
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: "./tests",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: "http://localhost:3000",
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("ホームページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("should display the correct page title", async ({ page }) => {
+    await expect(page).toHaveTitle(/エルニーニョ動画配布サイト/);
+  });
+
+  test("should have proper page structure", async ({ page }) => {
+    // Check main container
+    const main = page.locator("main");
+    await expect(main).toBeVisible();
+
+    // Check main heading
+    const mainHeading = page.getByRole("heading", {
+      name: "エルニーニョ動画配布サイト",
+    });
+    await expect(mainHeading).toBeVisible();
+  });
+
+  test("should display player list section", async ({ page }) => {
+    // Check player list section
+    const playerSection = page.getByRole("heading", { name: /プレイヤー一覧/ });
+    await expect(playerSection).toBeVisible();
+
+    // Check description
+    const description = page.getByText("参加プレイヤーの一覧を表示します");
+    await expect(description).toBeVisible();
+  });
+});

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Navigation and Routing', () => {
+  test('should load home page successfully', async ({ page }) => {
+    const response = await page.goto('/');
+    
+    // Check that the page loads successfully
+    expect(response?.status()).toBe(200);
+    
+    // Check that we're on the correct page
+    await expect(page).toHaveURL('/');
+  });
+
+  test('should handle non-existent routes gracefully', async ({ page }) => {
+    // This will test Next.js 404 handling when we implement proper error pages
+    const response = await page.goto('/non-existent-page');
+    
+    // Next.js should return a 404 page
+    expect(response?.status()).toBe(404);
+  });
+
+  test('should have proper meta tags', async ({ page }) => {
+    await page.goto('/');
+    
+    // Check that viewport meta tag exists (for mobile responsiveness)
+    const viewport = page.locator('meta[name="viewport"]');
+    await expect(viewport).toHaveAttribute('content', /width=device-width/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     globals: true,
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/cypress/**",
+      "**/.{idea,git,cache,output,temp}/**",
+      "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*",
+      "tests/**/*", // Exclude Playwright test files
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
```
  導入内容

  🎯 完了した作業

  - Playwright パッケージのインストール: @playwright/test を追加
  - Playwright設定: playwright.config.ts でNext.js用のbaseURL設定
  - ブラウザのインストール: Chromium, Firefox, WebKit
  - package.jsonスクリプト追加:
    - test:e2e: E2Eテスト実行
    - test:e2e:ui: UIモードでのテスト実行
    - test:e2e:headed: ブラウザ表示でのテスト実行
  - GitHub Actions CI/CD統合: PR時のE2Eテスト自動実行とレポート保存
  - プロジェクト固有テスト: エルニーニョ動画配布サイト用のテストケース作成

  🧪 作成されたテストファイル

  - tests/elnino-home.spec.ts: ホームページの詳細テスト
  - tests/navigation.spec.ts: ナビゲーション・ルーティングテスト

  ✅ 動作確認済み
```